### PR TITLE
feat: set a configurable timeout with default value

### DIFF
--- a/.github/workflows/cdk-deploy.yaml
+++ b/.github/workflows/cdk-deploy.yaml
@@ -14,24 +14,35 @@ on:
       environment:
         description: 배포 환경 구분
         required: true
-        type: string 
+        type: string
       image-tag:
         description: 배포에 사용할 이미지 태그
         required: true
-        type: string 
+        type: string
+      timeout-minutes:
+        description: 작업의 타임아웃 시간 (분)
+        required: false
+        type: number
+        default: 30
 
     secrets:
       AWS_ACCESS_KEY_ID:
-        description: 'AWS 액세스 키 ID'
+        description: "AWS 액세스 키 ID"
         required: true
       AWS_SECRET_ACCESS_KEY:
-        description: 'AWS 시크릿 액세스 키'
+        description: "AWS 시크릿 액세스 키"
         required: true
       PERSONAL_TOKEN:
         required: true
 
 jobs:
   cdk-deploy:
+    strategy:
+      matrix:
+        timeout-minutes:
+          - ${{ inputs.timeout-minutes }}
+    timeout-minutes: ${{ matrix.timeout-minutes }}
+
     if: "${{ !(endsWith(github.ref, '/main') && startsWith(github.event.head_commit.message, 'chore: release v')) }}"
 
     runs-on: ubuntu-latest
@@ -58,14 +69,14 @@ jobs:
           env: ${{ env.STACK_NAME }}
           ref: ${{ github.head_ref }}
 
-      - uses: actions/checkout@v3 
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: cdk/package-lock.json
-          registry-url: 'https://npm.pkg.github.com'
+          registry-url: "https://npm.pkg.github.com"
 
       - uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -86,7 +97,7 @@ jobs:
       - uses: sergeysova/jq-action@v2
         id: deploy-url
         with:
-          cmd: "jq '.\"${{ env.STACK_NAME }}\".deployUrl' ./cdk/cdk-outputs.json -r"
+          cmd: 'jq ''."${{ env.STACK_NAME }}".deployUrl'' ./cdk/cdk-outputs.json -r'
 
       - uses: bobheadxi/deployments@v1
         if: always()

--- a/.github/workflows/ecr-login-and-build-and-push.yaml
+++ b/.github/workflows/ecr-login-and-build-and-push.yaml
@@ -41,8 +41,8 @@ jobs:
   build-and-push:
     strategy:
       matrix:
-        test-timeout:
-          - ${{ inputs.test-timeout }}
+        timeout-minutes:
+          - ${{ inputs.timeout-minutes }}
     timeout-minutes: ${{ matrix.timeout-minutes }}
 
     if: "${{ !(endsWith(github.ref, '/main') && startsWith(github.event.head_commit.message, 'chore: release v')) }}"

--- a/.github/workflows/ecr-login-and-build-and-push.yaml
+++ b/.github/workflows/ecr-login-and-build-and-push.yaml
@@ -38,8 +38,13 @@ on:
         required: true
 
 jobs:
-  timeout-minutes: ${{ inputs.timeout-minutes }}
   build-and-push:
+    strategy:
+      matrix:
+        test-timeout:
+          - ${{ inputs.test-timeout }}
+    timeout-minutes: ${{ matrix.timeout-minutes }}
+
     if: "${{ !(endsWith(github.ref, '/main') && startsWith(github.event.head_commit.message, 'chore: release v')) }}"
 
     runs-on: ubuntu-latest-8-cores

--- a/.github/workflows/ecr-login-and-build-and-push.yaml
+++ b/.github/workflows/ecr-login-and-build-and-push.yaml
@@ -23,16 +23,22 @@ on:
         description: 이미지 푸시할 때 보조로 사용할 이미지 태그
         required: false
         type: string
+      timeout-minutes:
+        description: 작업의 타임아웃 시간 (분)
+        required: false
+        type: number
+        default: 30
 
     secrets:
       AWS_ACCESS_KEY_ID:
-        description: 'AWS 액세스 키 ID'
+        description: "AWS 액세스 키 ID"
         required: true
       AWS_SECRET_ACCESS_KEY:
-        description: 'AWS 시크릿 액세스 키'
+        description: "AWS 시크릿 액세스 키"
         required: true
 
 jobs:
+  timeout-minutes: ${{ inputs.timeout-minutes }}
   build-and-push:
     if: "${{ !(endsWith(github.ref, '/main') && startsWith(github.event.head_commit.message, 'chore: release v')) }}"
 
@@ -52,7 +58,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@v2
 
-      - run: |      
+      - run: |
           ecr_registry_and_repository=${{ steps.ecr.outputs.registry }}/${{ inputs.ecr-repository }}
 
           if [ -z "${{ inputs.alias-tag }}" ]
@@ -69,13 +75,13 @@ jobs:
           build-args: ${{ inputs.docker-build-args }}
           # cache-from: type=gha
           # cache-to: type=gha,mode=max
-      
+
       - if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@v2
         id: comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
+          comment-author: "github-actions[bot]"
           body-includes: 도커 이미지가 빌드되었습니다.
 
       - if: github.event_name == 'pull_request'


### PR DESCRIPTION
- 액션이 호출되는 시점에 타임아웃을 주입받을 수 있게 했습니다.
- 기본 타임아웃은 30분입니다.
- buildy-app-api의 워크플로우에서 `jobs.build-and-push.with.timeout-minutes`를 1로 설정한 상태에서 워크플로우를 테스트했을 때, 기대한 대로 1분 시점에 타임아웃이 났습니다. 

TMI: 기본적으로 다른 액션으로부터 `timeout-minutes`를 변수로 넘겨받을 수는 없는 것 같아서, [matrix 설정](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix)을 통해 workaround를 적용했습니다. ([github issue 링크](https://github.com/actions/runner/issues/1555#issuecomment-992339079))