### PR TITLE
ci: bump actions to Node 24 runtime versions

### DIFF
--- a/.github/workflows/cdk-deploy.yaml
+++ b/.github/workflows/cdk-deploy.yaml
@@ -69,16 +69,16 @@ jobs:
           env: ${{ env.STACK_NAME }}
           ref: ${{ github.head_ref }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: "npm"
           cache-dependency-path: cdk/package-lock.json
           registry-url: "https://npm.pkg.github.com"
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ecr-login-and-build-and-push.yaml
+++ b/.github/workflows/ecr-login-and-build-and-push.yaml
@@ -60,9 +60,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -71,7 +71,7 @@ jobs:
       - id: ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - run: |
           ecr_registry_and_repository=${{ steps.ecr.outputs.registry }}/${{ inputs.ecr-repository }}
@@ -98,7 +98,7 @@ jobs:
           echo "DOCKERFILE=$DOCKERFILE" >> $GITHUB_ENV
           echo "BUILD_CONTEXT=$BUILD_CONTEXT" >> $GITHUB_ENV
 
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v7
         with:
           push: true
           tags: ${{ env.DOCKER_TAGS }}
@@ -109,7 +109,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - if: github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v4
         id: comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -117,7 +117,7 @@ jobs:
           body-includes: 도커 이미지가 빌드되었습니다.
 
       - if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -126,6 +126,6 @@ jobs:
           edit-mode: replace
 
       - if: github.event_name == 'pull_request'
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: preview
+        run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label preview
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## 배경
GitHub이 Actions의 Node.js 20 런타임을 폐기 중입니다. 러너는 Node 20 기반 액션을 강제로 Node 24에서 실행하면서 경고를 띄우고, 2026-09-16에는 Node 20이 완전히 제거됩니다. `build-and-push`, `cdk-deploy` 잡에서 해당 경고가 발생하여, 경고에 명시된 액션들을 Node 24 런타임 버전으로 올립니다.

## 변경 사항
**`ecr-login-and-build-and-push.yaml`**
- `actions/checkout@v4 → @v5`
- `aws-actions/configure-aws-credentials@v4 → @v5`
- `docker/setup-buildx-action@v3 → @v4`
- `docker/build-push-action@v5 → @v7`
- `peter-evans/find-comment@v2 → @v4`
- `peter-evans/create-or-update-comment@v2 → @v5`
- `actions-ecosystem/action-add-labels@v1` (유지보수 중단·Node 24 릴리스 없음) → `gh pr edit ... --add-label preview` run 스텝으로 교체

**`cdk-deploy.yaml`**
- `actions/checkout@v4 → @v5`
- `actions/setup-node@v4 → @v5` (`node-version: 20` 입력값은 CDK 빌드 런타임이라 유지)
- `aws-actions/configure-aws-credentials@v4 → @v5`

## 주의
- `bobheadxi/deployments@v1`은 **Node 24 릴리스가 없어 그대로 둠** — 이 액션 경고 1건은 남으며, 2026-09-16 Node 20 제거 전에 대체 검토 필요.
- `gh pr edit`는 기존 `action-add-labels`와 동일하게 기본 `GITHUB_TOKEN`을 사용 → 권한 동작 변화 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)